### PR TITLE
[KTMF-7] BUG: Board name too long

### DIFF
--- a/components/reusables/SidebarMenuListItem.tsx
+++ b/components/reusables/SidebarMenuListItem.tsx
@@ -9,10 +9,36 @@ const SidebarMenuListItem = ({name, active, index}: SidebarMenuListItemProps)=> 
     <div 
       data-testid="board-list-item" 
       onClick={()=> setSelectedBoard(index)}
-      className={`${styles.boardButton} flex flex-row items-center ${active ? 'bg-purple font-bold text-white hover:bg-purple hover:dark:bg-purple hover:text-white' : ''} text-grey-400 hover:bg-grey-200 hover:dark:bg-white hover:text-purple`}
+      className={`
+        ${styles.boardButton} 
+        flex 
+        flex-row 
+        items-center ${active ? 
+          'bg-purple font-bold text-white hover:bg-purple hover:dark:bg-purple hover:text-white' : 
+          ''} 
+        text-grey-400 
+        hover:bg-grey-200 
+        hover:dark:bg-white 
+        hover:text-purple
+      `}
     >
-      <img src="images/icon-board.svg" alt="board" className={`${active ? styles.active : ''}`}/>
-      <span>{name}</span>  
+      <img 
+        src="images/icon-board.svg" 
+        alt="board" 
+        className={`
+          ${active ? 
+          styles.active : 
+          ''
+          }
+        `}
+      />
+      <span
+        className='
+          whitespace-nowrap
+          text-ellipsis
+          overflow-hidden
+        '
+      >{name}</span>  
     </div>
   )
 }


### PR DESCRIPTION
Describe the issue: When there is a long name for a board the name goes to the second line
Steps to reproduce: When creating a board enter a long name for a board

Desired outcome: Name should end with … if it’s too long